### PR TITLE
PO-3696 add creditor_account_version to minor creditor at a glance stub

### DIFF
--- a/wiremock/__files/legacy/MinorCreditor/getMinorCreditorAtAGlance.xml
+++ b/wiremock/__files/legacy/MinorCreditor/getMinorCreditorAtAGlance.xml
@@ -15,6 +15,7 @@
   </address>
 
   <creditor_account_id>99000000000801</creditor_account_id>
+  <creditor_account_version>1</creditor_account_version>
 
   <defendant>
     <account_number>12345678</account_number>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3696


### Change description ###
Adds creditor_account_version to the legacy stub response for minor creditor at a glance so etag can be returned correctly during integration testing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
