### PR TITLE
PO-1993 add minor creditor PATCH legacy stub mappings

### DIFF
--- a/wiremock/__files/legacy/MinorCreditor/patchMinorCreditorAccount.xml
+++ b/wiremock/__files/legacy/MinorCreditor/patchMinorCreditorAccount.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <account_version>2</account_version>
+  <creditor_account_id>607</creditor_account_id>
+  <party_details>
+    <party_id>99008</party_id>
+    <organisation_flag>true</organisation_flag>
+    <organisation_details>
+      <organisation_name>Updated Ltd</organisation_name>
+    </organisation_details>
+  </party_details>
+  <address>
+    <address_line_1>99 Updated Road</address_line_1>
+    <address_line_2>Updated Area</address_line_2>
+    <address_line_3>Updated Town</address_line_3>
+    <postcode>NW1 1AA</postcode>
+  </address>
+  <payment>
+    <account_name>Updated Account</account_name>
+    <sort_code>112233</sort_code>
+    <account_number>12345678</account_number>
+    <account_reference>Ref-01</account_reference>
+    <pay_by_bacs>true</pay_by_bacs>
+    <hold_payment>true</hold_payment>
+  </payment>
+</response>

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount.json
@@ -1,38 +1,15 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/opal",
+    "urlPathPattern": "/opal",
     "queryParameters": {
       "actionType": {
         "equalTo": "LIBRA.of_update_minor_creditor_account"
       }
     },
-    "bodyPatterns": [
-      {
-        "matchesJsonPath": {
-          "expression": "$.creditor_account_id",
-          "equalTo": "607"
-        }
-      },
-      {
-        "matchesJsonPath": {
-          "expression": "$.business_unit_id",
-          "equalTo": "10"
-        }
-      },
-      {
-        "matchesJsonPath": {
-          "expression": "$.business_unit_user_id",
-          "equalTo": "USER01"
-        }
-      },
-      {
-        "matchesJsonPath": {
-          "expression": "$.account_version",
-          "equalTo": "1"
-        }
-      }
-    ]
+    "bodyPatterns": [ {
+      "matchesJsonPath": "$[?(@.creditor_account_id == '607')]"
+    } ]
   },
   "response": {
     "status": 200,

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount.json
@@ -1,0 +1,44 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.of_update_minor_creditor_account"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": {
+          "expression": "$.creditor_account_id",
+          "equalTo": "607"
+        }
+      },
+      {
+        "matchesJsonPath": {
+          "expression": "$.business_unit_id",
+          "equalTo": "10"
+        }
+      },
+      {
+        "matchesJsonPath": {
+          "expression": "$.business_unit_user_id",
+          "equalTo": "USER01"
+        }
+      },
+      {
+        "matchesJsonPath": {
+          "expression": "$.account_version",
+          "equalTo": "1"
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/xml"
+    },
+    "bodyFileName": "legacy/MinorCreditor/patchMinorCreditorAccount.xml"
+  }
+}

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount.json
@@ -9,6 +9,20 @@
     },
     "bodyPatterns": [ {
       "matchesJsonPath": "$[?(@.creditor_account_id == '607')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_user_id == 'USER01')]"
+    }, {
+      "matchesJsonPath": "$[?(@.account_version == 1)]"
+    }, {
+      "matchesJsonPath": "$[?(@.party_details.party_id == '99008')]"
+    }, {
+      "matchesJsonPath": "$[?(@.address.address_line_1 == '99 Updated Road')]"
+    }, {
+      "matchesJsonPath": "$[?(@.payment.account_reference == 'Ref-01')]"
+    }, {
+      "matchesJsonPath": "$[?(@.payment.hold_payment == true)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_404response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_404response.json
@@ -9,14 +9,14 @@
       }
     },
     "bodyPatterns": [ {
-      "matchesJsonPath": "$[?(@.creditor_account_id == '500')]"
+      "matchesJsonPath": "$[?(@.creditor_account_id == '404')]"
     } ]
   },
   "response": {
-    "status": 500,
+    "status": 404,
     "headers": {
-      "Content-Type": "text/plain"
+      "Content-Type": "application/xml"
     },
-    "body": "Legacy minor creditor update failed"
+    "body": "<error><message>Minor creditor account not found</message></error>"
   }
 }

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_404response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_404response.json
@@ -10,6 +10,10 @@
     },
     "bodyPatterns": [ {
       "matchesJsonPath": "$[?(@.creditor_account_id == '404')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
+    }, {
+      "matchesJsonPath": "$[?(@.account_version == 1)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_408response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_408response.json
@@ -10,6 +10,10 @@
     },
     "bodyPatterns": [ {
       "matchesJsonPath": "$[?(@.creditor_account_id == '408')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
+    }, {
+      "matchesJsonPath": "$[?(@.account_version == 1)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_408response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_408response.json
@@ -1,0 +1,22 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.of_update_minor_creditor_account"
+      }
+    },
+    "bodyPatterns": [ {
+      "matchesJsonPath": "$[?(@.creditor_account_id == '408')]"
+    } ]
+  },
+  "response": {
+    "status": 408,
+    "headers": {
+      "Content-Type": "text/plain"
+    },
+    "body": "Legacy minor creditor update timed out"
+  }
+}

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_409response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_409response.json
@@ -13,7 +13,7 @@
     }, {
       "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
     }, {
-      "matchesJsonPath": "$[?(@.account_version == 1)]"
+      "matchesJsonPath": "$[?(@.account_version == 2)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_409response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_409response.json
@@ -9,14 +9,14 @@
       }
     },
     "bodyPatterns": [ {
-      "matchesJsonPath": "$[?(@.creditor_account_id == '500')]"
+      "matchesJsonPath": "$[?(@.creditor_account_id == '409')]"
     } ]
   },
   "response": {
-    "status": 500,
+    "status": 409,
     "headers": {
-      "Content-Type": "text/plain"
+      "Content-Type": "application/xml"
     },
-    "body": "Legacy minor creditor update failed"
+    "body": "<error><message>Minor creditor account version conflict</message></error>"
   }
 }

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_409response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_409response.json
@@ -10,6 +10,10 @@
     },
     "bodyPatterns": [ {
       "matchesJsonPath": "$[?(@.creditor_account_id == '409')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
+    }, {
+      "matchesJsonPath": "$[?(@.account_version == 1)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_500response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_500response.json
@@ -10,6 +10,10 @@
     },
     "bodyPatterns": [ {
       "matchesJsonPath": "$[?(@.creditor_account_id == '500')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
+    }, {
+      "matchesJsonPath": "$[?(@.account_version == 1)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_500response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_500response.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.of_update_minor_creditor_account"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": {
+          "expression": "$.creditor_account_id",
+          "equalTo": "500"
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 500,
+    "headers": {
+      "Content-Type": "text/plain"
+    },
+    "body": "Legacy minor creditor update failed"
+  }
+}

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_503response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_503response.json
@@ -10,6 +10,10 @@
     },
     "bodyPatterns": [ {
       "matchesJsonPath": "$[?(@.creditor_account_id == '503')]"
+    }, {
+      "matchesJsonPath": "$[?(@.business_unit_id == '10')]"
+    }, {
+      "matchesJsonPath": "$[?(@.account_version == 1)]"
     } ]
   },
   "response": {

--- a/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_503response.json
+++ b/wiremock/mappings/legacy/MinorCreditor/patchMinorCreditorAccount_503response.json
@@ -9,14 +9,14 @@
       }
     },
     "bodyPatterns": [ {
-      "matchesJsonPath": "$[?(@.creditor_account_id == '500')]"
+      "matchesJsonPath": "$[?(@.creditor_account_id == '503')]"
     } ]
   },
   "response": {
-    "status": 500,
+    "status": 503,
     "headers": {
       "Content-Type": "text/plain"
     },
-    "body": "Legacy minor creditor update failed"
+    "body": "Legacy minor creditor update unavailable"
   }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-1993

### Change description ###
Added legacy stub support for LIBRA.of_update_minor_creditor_account in opal-legacy-db-stub, including the happy-path PATCH mapping and response XML for minor creditor account updates. The success response now returns the fields fines-service expects, including account version, creditor account id, party details, address, and payment details. I also added 404, 409, 500, and 503 variants using the existing POST /opal plus actionType matching style, with scenarios distinguished by creditor_account_id.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
