### PR TITLE
PO-2136 Add major creditor header summary legacy stub

### DIFF
--- a/wiremock/__files/legacy/MajorCreditor/getMajorCreditorHeaderSummary.xml
+++ b/wiremock/__files/legacy/MajorCreditor/getMajorCreditorHeaderSummary.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <major_creditor>
+    <creditor_account_id>99000000000800</creditor_account_id>
+    <account_version>7</account_version>
+    <account_number>87654321</account_number>
+    <name>Major Creditor Test Ltd</name>
+    <account_reference>
+      <account_type>MJ</account_type>
+    </account_reference>
+  </major_creditor>
+
+  <business_unit_details>
+    <business_unit_id>77</business_unit_id>
+    <business_unit_name>Camberwell Green</business_unit_name>
+    <welsh_speaking>N</welsh_speaking>
+  </business_unit_details>
+
+  <awaiting_payout>123.45</awaiting_payout>
+</response>

--- a/wiremock/mappings/legacy/MajorCreditor/MajorCreditorGetHeaderSummary.json
+++ b/wiremock/mappings/legacy/MajorCreditor/MajorCreditorGetHeaderSummary.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.get_major_creditor_account_header_summary"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": {
+          "expression": "$.creditorAccountId",
+          "equalTo": "99000000000800"
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/xml"
+    },
+    "bodyFileName": "legacy/MajorCreditor/getMajorCreditorHeaderSummary.xml"
+  }
+}

--- a/wiremock/mappings/legacy/MajorCreditor/MajorCreditorGetHeaderSummary_500Response.json
+++ b/wiremock/mappings/legacy/MajorCreditor/MajorCreditorGetHeaderSummary_500Response.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.get_major_creditor_account_header_summary"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": {
+          "expression": "$.creditorAccountId",
+          "equalTo": "500"
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 500,
+    "headers": {
+      "Content-Type": "application/xml"
+    },
+    "bodyFileName": "legacy/InternalServerError/internalServerErrorResponse.xml"
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2136


### Change description ###
- Added WireMock mapping for LIBRA.get_major_creditor_account_header_summary
- Added successful XML response for creditorAccountId 99000000000800
- Added 500 error mapping for creditorAccountId 500
- Response includes major creditor details, business unit details, awaiting_payout, and account_version for ETag handling

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
