### PR TITLE
PO-2078-Added-Extra-Json/XML-Files-For-Impositions.

### DIFF
--- a/wiremock/__files/legacy/DefendantAccount/getImpositions.xml
+++ b/wiremock/__files/legacy/DefendantAccount/getImpositions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <version>1</version>
+  <impositions>
+    <balance>540</balance>
+    <creditor>
+      <account_type>MN</account_type>
+      <creditor_account_id>99000000000806</creditor_account_id>
+      <display_name>Minor Creditor</display_name>
+      <major_creditor_id></major_creditor_id>
+      <minor_creditor_party_id>99000000000906</minor_creditor_party_id>
+      <name>Metropolitan Traffic Unit</name>
+    </creditor>
+    <date_added>2026-05-06</date_added>
+    <date_imposed></date_imposed>
+    <imposed_amount>600</imposed_amount>
+    <imposed_by></imposed_by>
+    <imposition>
+      <result_id>ABDC</result_id>
+      <result_title>Application made for Benefit Deductions</result_title>
+    </imposition>
+    <imposition_id>99000000003006</imposition_id>
+    <offence>
+      <code>OFF0006</code>
+      <id></id>
+      <title>Test Offence 6</title>
+    </offence>
+    <paid_amount>60</paid_amount>
+  </impositions>
+</response>

--- a/wiremock/mappings/legacy/DefendantAccount/getImpositions.json
+++ b/wiremock/mappings/legacy/DefendantAccount/getImpositions.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.get_impositions"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/xml"
+    },
+    "bodyFileName": "legacy/DefendantAccount/getImpositions.xml"
+  }
+}


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/PO-2078###



### Adds Legacy DB stub support for the Get Defendant Account Impositions endpoint.###

Changes include:
- Added WireMock mapping for `LIBRA.get_impositions`.
- Added the Legacy XML response body used by the stub.
- Provides stubbed Legacy imposition data for `/defendant-accounts/{defendantAccountId}/impositions` testing in Legacy mode.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
