### PR TITLE
PO-2137-Add legacy stubs for getMajorCreditorAccountAtAGlance

### DIFF
--- a/wiremock/__files/legacy/MajorCreditor/getMajorCreditorAtAGlance.xml
+++ b/wiremock/__files/legacy/MajorCreditor/getMajorCreditorAtAGlance.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<response>
+  <major_creditor>
+    <creditor_account_id>99000000000800</creditor_account_id>
+    <creditor_account_version>7</creditor_account_version>
+    <name>Major Creditor Test Ltd</name>
+    <code>MC01</code>
+    <address>
+      <line_1>1 Test Street</line_1>
+      <line_2>London</line_2>
+      <line_3>NW1</line_3>
+      <postcode>NW1 1AA</postcode>
+    </address>
+    <pay_by_bacs>true</pay_by_bacs>
+  </major_creditor>
+</response>

--- a/wiremock/mappings/legacy/MajorCreditor/MajorCreditorGetAtAGlance.json
+++ b/wiremock/mappings/legacy/MajorCreditor/MajorCreditorGetAtAGlance.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/opal",
+    "queryParameters": {
+      "actionType": {
+        "equalTo": "LIBRA.get_major_creditor_account_at_a_glance"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": {
+          "expression": "$.creditorAccountId",
+          "equalTo": "99000000000800"
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/xml"
+    },
+    "bodyFileName": "legacy/MajorCreditor/getMajorCreditorAtAGlance.xml"
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-2137

### Change description ###

- Adds WireMock mapping for LIBRA.get_major_creditor_account_at_a_glance
- Adds XML stub response for major creditor at-a-glance
- Supports local legacy stub integration for GET /major-creditor-accounts/{id}/at-a-glance

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
