### PR TITLE
Update spring-framework.version to 7.0.8 to cover CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,7 @@ repositories {
 
 ext {
   log4JVersion = "2.26.0"
+  set('spring-framework.version', "7.0.8")
 }
 
 ext['tomcat.version'] = '11.0.22'


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
