### PR TITLE
Pin the 'publish openapi' yaml document for SonarQube security reasons.

### DIFF
--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-openapi:
-    uses: hmcts/workflow-publish-openapi-spec/.github/workflows/publish-openapi.yml@v1
+    uses: hmcts/workflow-publish-openapi-spec/.github/workflows/publish-openapi.yml@caa170cb8dd959f12c1c0374f80021336daacfa2
     secrets:
       SWAGGER_PUBLISHER_API_TOKEN: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
     with:


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
