### PR TITLE
CVE-2026-66299 - temporary suppression till 15-Sep-2026

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,5 +46,18 @@
     <cve>CVE-2025-48924</cve>
     <cve>CVE-2026-54399</cve>
   </suppress>
+  <suppress until="2026-09-15Z">
+    <notes><![CDATA[
+    Reviewed 2026-08-10.
+    CVE-2026-66299 is a Low severity DoS in the Tomcat WebSocket chat example.
+    Apache lists the fix under Tomcat 11.0.25, but that release is currently marked
+    as "not yet released". This service embeds Tomcat and does not ship Tomcat's
+    examples web application, so the vulnerable example is not part of the deployed
+    application. Keep this suppression only for Tomcat 11.0.24 embed artifacts until
+    a released Tomcat 11.0.25 or later is available.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-(core|websocket)@11\.0\.24$</packageUrl>
+    <cve>CVE-2026-66299</cve>
+  </suppress>
   <!--End of false positives section -->
 </suppressions>


### PR DESCRIPTION
    CVE-2026-66299 is a Low severity DoS in the Tomcat WebSocket chat example.
    Apache lists the fix under Tomcat 11.0.25, but that release is currently marked
    as "not yet released". This service embeds Tomcat and does not ship Tomcat's
    examples web application, so the vulnerable example is not part of the deployed
    application. Keep this suppression only for Tomcat 11.0.24 embed artifacts until
    a released Tomcat 11.0.25 or later is available.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
